### PR TITLE
Add support for HSV output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ ChangeLog
  - roi instead of single pixel
  - raw input yuv image support
  - add arg for filtering type (avg, med)
+ - add output hsv support
 
 ### Changed
  - arg parser

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ $ sudo pip install opencv-python
 ```
 
 ## Usage
-Output format supported: rgb, yuv
+Output format supported: rgb, yuv, hsv
 
 ```
 $ ./colorscope.py -i image.jpeg -out_fmt=rgb

--- a/colorscope.py
+++ b/colorscope.py
@@ -191,6 +191,8 @@ class ColorReader(metaclass=abc.ABCMeta):
       return ColorReaderRGB(image_loader, filter_type)
     if color_format == 'yuv':
       return ColorReaderYUV(image_loader, filter_type)
+    if color_format == 'hsv':
+      return ColorReaderHSV(image_loader, filter_type)
     raise AttributeError('make_color_reader: ' + color_format + ' not found')
 
 
@@ -210,6 +212,15 @@ class ColorReaderYUV(ColorReader):
 
   def _get_color_format(self, img_roi):
     return cv2.cvtColor(img_roi, cv2.COLOR_BGR2YUV)
+
+
+class ColorReaderHSV(ColorReader):
+  def __init__(self, filename, filter_type='avg'):
+    super().__init__(filename, filter_type)
+    print('H', 'S', 'V', sep='\t')
+
+  def _get_color_format(self, img_roi):
+    return cv2.cvtColor(img_roi, cv2.COLOR_BGR2HSV)
 
 
 def parse_video_size_arg(video_size):
@@ -246,7 +257,7 @@ def main():
       '-out_fmt',
       '--output_format',
       type=str,
-      help='Output rgb, yuv (Default: rgb)',
+      help='Output rgb, yuv, hsv (Default: rgb)',
       default='rgb'
   )
 

--- a/tst_colorscope.py
+++ b/tst_colorscope.py
@@ -111,6 +111,7 @@ class TestColorscope(unittest.TestCase):
     imloader = colorscope.ImageLoaderDefault(self.res.red)
     colorscope.ColorReader.create('rgb', imloader, 'avg')
     colorscope.ColorReader.create('yuv', imloader, 'avg')
+    colorscope.ColorReader.create('hsv', imloader, 'avg')
 
     with self.assertRaises(AttributeError):
       colorscope.ColorReader.create('', '', '')
@@ -234,7 +235,7 @@ class TestColorscope(unittest.TestCase):
   def test_color_hsv_green(self):
      img_file = self.res.green
      img_loader = colorscope.ImageLoaderDefault(img_file)
-     cr_hsv = ColorReaderRgbMock(img_loader)
+     cr_hsv = ColorReaderHsvMock(img_loader)
      hsv = cr_hsv.read_rect_color(self.res.rect)
      self.assertEqual(hsv , [60, 255, 255])
 
@@ -267,7 +268,7 @@ class TestColorscope(unittest.TestCase):
   def test_color_hsv_blue(self):
      img_file = self.res.blue
      img_loader = colorscope.ImageLoaderDefault(img_file)
-     cr_hsv = ColorReaderRgbMock(img_loader)
+     cr_hsv = ColorReaderHsvMock(img_loader)
      hsv = cr_hsv.read_rect_color(self.res.rect)
      self.assertEqual(hsv , [120, 255, 255])
 
@@ -300,7 +301,7 @@ class TestColorscope(unittest.TestCase):
   def test_color_hsv_black(self):
      img_file = self.res.black
      img_loader = colorscope.ImageLoaderDefault(img_file)
-     cr_hsv = ColorReaderRgbMock(img_loader)
+     cr_hsv = ColorReaderHsvMock(img_loader)
      hsv = cr_hsv.read_rect_color(self.res.rect)
      self.assertEqual(hsv , [0, 0, 0])
 
@@ -333,7 +334,7 @@ class TestColorscope(unittest.TestCase):
   def test_color_hsv_white(self):
      img_file = self.res.white
      img_loader = colorscope.ImageLoaderDefault(img_file)
-     cr_hsv = ColorReaderRgbMock(img_loader)
+     cr_hsv = ColorReaderHsvMock(img_loader)
      hsv = cr_hsv.read_rect_color(self.res.rect)
      self.assertEqual(hsv , [255, 255, 255])
 

--- a/tst_colorscope.py
+++ b/tst_colorscope.py
@@ -336,7 +336,7 @@ class TestColorscope(unittest.TestCase):
      img_loader = colorscope.ImageLoaderDefault(img_file)
      cr_hsv = ColorReaderHsvMock(img_loader)
      hsv = cr_hsv.read_rect_color(self.res.rect)
-     self.assertEqual(hsv , [255, 255, 255])
+     self.assertEqual(hsv, [0, 0, 255])
 
   def test_color_yuv_white(self):
     img_file = self.res.white
@@ -355,7 +355,7 @@ class TestColorscope(unittest.TestCase):
     img_file = self.res.white
     color_filter = colorscope.ColorChannelFilterAverage()
     r, g, b = color_filter.filter(cv2.imread(img_file))
-    self.assertEqual([b, g, r] , [0, 0, 255])
+    self.assertEqual([b, g, r] , [255, 255, 255])
 
   def close_window(self):
     if fake_xwindow_supported():

--- a/tst_colorscope.py
+++ b/tst_colorscope.py
@@ -51,10 +51,10 @@ class Resources:
 
       os.system('ffmpeg -f rawvideo -video_size 1920x1080 -pixel_format nv12 -i /dev/urandom -vframes 1 raw_nv12_1920_1080.yuv')
       os.system('ffmpeg -f rawvideo -video_size 1920x1080 -pixel_format nv21 -i /dev/urandom -vframes 1 raw_nv21_1920_1080.yuv')
-    
+
       self.raw_nv12_1920_1080 = 'raw_nv12_1920_1080.yuv'
       self.raw_nv21_1920_1080 = 'raw_nv21_1920_1080.yuv'
-    
+
       self.raw_nv12_1280_720 = 'raw_nv12_1280_720.yuv'
       self.raw_nv21_1280_720 = 'raw_nv21_1280_720.yuv'
 
@@ -75,7 +75,7 @@ class Resources:
     img_blue.save(self.blue)
     img_white.save(self.white)
     img_black.save(self.black)
-  
+
   def __del__(self):
     os.remove(self.red)
     os.remove(self.green)
@@ -197,12 +197,12 @@ class TestColorscope(unittest.TestCase):
     cr_rgb = ColorReaderRgbMock(img_loader)
     rgb = cr_rgb.read_rect_color(self.res.rect)
     self.assertEqual(rgb , [255, 0, 0])
-  
+
   def test_color_hsv_red(self):
     img_file = self.res.red
     img_loader = colorscope.ImageLoaderDefault(img_file)
-    cr_rgb = ColorReaderHsvMock(img_loader)
-    hsv = cr_rgb.read_rect_color(self.res.rect)
+    cr_hsv = ColorReaderHsvMock(img_loader)
+    hsv = cr_hsv.read_rect_color(self.res.rect)
     self.assertEqual(hsv , [0, 255, 255])
 
   def test_color_yuv_red(self):
@@ -211,7 +211,7 @@ class TestColorscope(unittest.TestCase):
     cr_yuv = ColorReaderYuvMock(img_loader)
     yuv = cr_yuv.read_rect_color(self.res.rect)
     self.assertEqual(yuv, [76, 91, 255])
-  
+
   def test_color_filter_median_red(self):
     img_file = self.res.red
     color_filter = colorscope.ColorChannelFilterMedian()
@@ -230,14 +230,21 @@ class TestColorscope(unittest.TestCase):
      cr_rgb = ColorReaderRgbMock(img_loader)
      rgb = cr_rgb.read_rect_color(self.res.rect)
      self.assertEqual(rgb , [0, 255, 0])
-  
+
+  def test_color_hsv_green(self):
+     img_file = self.res.green
+     img_loader = colorscope.ImageLoaderDefault(img_file)
+     cr_hsv = ColorReaderRgbMock(img_loader)
+     hsv = cr_hsv.read_rect_color(self.res.rect)
+     self.assertEqual(hsv , [60, 255, 255])
+
   def test_color_yuv_green(self):
     img_file = self.res.green
     img_loader = colorscope.ImageLoaderDefault(img_file)
     cr_yuv = ColorReaderYuvMock(img_loader)
     yuv = cr_yuv.read_rect_color(self.res.rect)
     self.assertEqual(yuv, [150, 54, 0])
-  
+
   def test_color_filter_median_green(self):
     img_file = self.res.green
     color_filter = colorscope.ColorChannelFilterMedian()
@@ -256,14 +263,21 @@ class TestColorscope(unittest.TestCase):
      cr_rgb = ColorReaderRgbMock(img_loader)
      rgb = cr_rgb.read_rect_color(self.res.rect)
      self.assertEqual(rgb , [0, 0, 255])
-  
+
+  def test_color_hsv_blue(self):
+     img_file = self.res.blue
+     img_loader = colorscope.ImageLoaderDefault(img_file)
+     cr_hsv = ColorReaderRgbMock(img_loader)
+     hsv = cr_hsv.read_rect_color(self.res.rect)
+     self.assertEqual(hsv , [120, 255, 255])
+
   def test_color_yuv_blue(self):
     img_file = self.res.blue
     img_loader = colorscope.ImageLoaderDefault(img_file)
     cr_yuv = ColorReaderYuvMock(img_loader)
     yuv = cr_yuv.read_rect_color(self.res.rect)
     self.assertEqual(yuv, [29, 239, 103])
-  
+
   def test_color_filter_median_blue(self):
     img_file = self.res.blue
     color_filter = colorscope.ColorChannelFilterMedian()
@@ -282,14 +296,21 @@ class TestColorscope(unittest.TestCase):
      cr_rgb = ColorReaderRgbMock(img_loader)
      rgb = cr_rgb.read_rect_color(self.res.rect)
      self.assertEqual(rgb , [0, 0, 0])
-  
+
+  def test_color_hsv_black(self):
+     img_file = self.res.black
+     img_loader = colorscope.ImageLoaderDefault(img_file)
+     cr_hsv = ColorReaderRgbMock(img_loader)
+     hsv = cr_hsv.read_rect_color(self.res.rect)
+     self.assertEqual(hsv , [0, 0, 0])
+
   def test_color_yuv_black(self):
     img_file = self.res.black
     img_loader = colorscope.ImageLoaderDefault(img_file)
     cr_yuv = ColorReaderYuvMock(img_loader)
     yuv = cr_yuv.read_rect_color(self.res.rect)
     self.assertEqual(yuv, [0, 128, 128])
-  
+
   def test_color_filter_median_black(self):
     img_file = self.res.black
     color_filter = colorscope.ColorChannelFilterMedian()
@@ -308,14 +329,21 @@ class TestColorscope(unittest.TestCase):
      cr_rgb = ColorReaderRgbMock(img_loader)
      rgb = cr_rgb.read_rect_color(self.res.rect)
      self.assertEqual(rgb , [255, 255, 255])
-  
+
+  def test_color_hsv_white(self):
+     img_file = self.res.white
+     img_loader = colorscope.ImageLoaderDefault(img_file)
+     cr_hsv = ColorReaderRgbMock(img_loader)
+     hsv = cr_hsv.read_rect_color(self.res.rect)
+     self.assertEqual(hsv , [255, 255, 255])
+
   def test_color_yuv_white(self):
     img_file = self.res.white
     img_loader = colorscope.ImageLoaderDefault(img_file)
     cr_yuv = ColorReaderYuvMock(img_loader)
     yuv = cr_yuv.read_rect_color(self.res.rect)
     self.assertEqual(yuv, [255, 128, 128])
-  
+
   def test_color_filter_median_white(self):
     img_file = self.res.white
     color_filter = colorscope.ColorChannelFilterMedian()
@@ -335,7 +363,7 @@ class TestColorscope(unittest.TestCase):
       start_pos = [50, 50]
       timeout = 3
       x, y = start_pos
-    
+
       sleep(timeout)
       fake_mouse.click(x, y)
       fake_keyboard.tap_esc()

--- a/tst_colorscope.py
+++ b/tst_colorscope.py
@@ -94,6 +94,11 @@ class ColorReaderYuvMock(colorscope.ColorReaderYUV):
     return super().read_rect_color(pos)
 
 
+class ColorReaderHsvMock(colorscope.ColorReaderHSV):
+  def read_rect_color(self, pos):
+    return super().read_rect_color(pos)
+
+
 class TestColorscope(unittest.TestCase):
   def setUp(self):
     if fake_xwindow_supported():
@@ -115,6 +120,7 @@ class TestColorscope(unittest.TestCase):
     imloader = colorscope.ImageLoaderDefault(self.res.red)
     csRGB = colorscope.ColorReaderRGB(imloader)
     csYUV = colorscope.ColorReaderYUV(imloader)
+    csHSV = colorscope.ColorReaderHSV(imloader)
 
     with self.assertRaises(TypeError):
       csINV = colorscope.ColorReader(imloader)
@@ -192,6 +198,13 @@ class TestColorscope(unittest.TestCase):
     rgb = cr_rgb.read_rect_color(self.res.rect)
     self.assertEqual(rgb , [255, 0, 0])
   
+  def test_color_hsv_red(self):
+    img_file = self.res.red
+    img_loader = colorscope.ImageLoaderDefault(img_file)
+    cr_rgb = ColorReaderHsvMock(img_loader)
+    hsv = cr_rgb.read_rect_color(self.res.rect)
+    self.assertEqual(hsv , [0, 255, 255])
+
   def test_color_yuv_red(self):
     img_file = self.res.red
     img_loader = colorscope.ImageLoaderDefault(img_file)

--- a/tst_colorscope.py
+++ b/tst_colorscope.py
@@ -355,7 +355,7 @@ class TestColorscope(unittest.TestCase):
     img_file = self.res.white
     color_filter = colorscope.ColorChannelFilterAverage()
     r, g, b = color_filter.filter(cv2.imread(img_file))
-    self.assertEqual([b, g, r] , [255, 255, 255])
+    self.assertEqual([b, g, r] , [0, 0, 255])
 
   def close_window(self):
     if fake_xwindow_supported():


### PR DESCRIPTION
* add HSV output format param

for example:
```
$ ./colorscope.py -i img_1920_1080_nv12.yuv -pix_fmt=nv12 -s 1920x1080 -out_fmt=hsv
H	S	V
132	132	32
123	123	115
```
